### PR TITLE
fix: add missing compats entries for JSON3 and StructTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed `list_assistant_models` endpoint URL placeholder from `{version}` to `{api_version}` to match the URL templating system
 
+
 ## [0.1.0] - 2025-01-20
 Initial release of Langdock.jl
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Langdock.jl will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.1.2] - 2026-01-08
+
+### Fixed
+- fix: add missing compat entries for JSON3 and StructTypes dependencies
+
 ## [0.1.1] - 2026-01-07
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -13,8 +13,10 @@ OpenSSL = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 
 [compat]
-OpenSSL = "1.5.0"
 HTTP = "1.10.19"
+JSON3 = "1.14.3"
+OpenSSL = "1.5.0"
+StructTypes = "1.11.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Langdock"
 uuid = "6ddf539a-d0a2-4e4a-9326-ccc383163d8c"
 authors = ["Pablo Valdunciel <pablo.vs@etik.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
### Fixed
- fix: add missing compat entries for JSON3 and StructTypes dependencies